### PR TITLE
Modified script to fix the unique id errors when running build

### DIFF
--- a/fixIds.py
+++ b/fixIds.py
@@ -1,18 +1,20 @@
 import re
 import os
 
+counter = 0
 idval = 1
 for root, dirs, files in os.walk("pretext"):
     for file in files:
+        counter += 1
         if "toctree" in file:
             continue
         if ".ptx" in file:
             with open(os.path.join(root, file)) as f:
                 text = f.read()
-            text = text.replace('"id1 ', '"')
-            text = text.replace('"id2 ', '"')
-            text = text.replace(" index-0", "")
-            text = text.replace(" index-1", "")
+            text = text.replace('"id1 ', f'{counter}_id1')
+            text = text.replace('"id2 ', f'{counter}_id2')
+            text = text.replace(" index-0", f"{counter}_index-0")
+            text = text.replace(" index-1", f"{counter}_index-1")
             text = re.sub(r'xml:id="([\w+-]+) ([\w+-]+)"', r'xml:id="\1"', text)
 
             with open(os.path.join(root, file), "w") as f:


### PR DESCRIPTION
1. added a counter variable at the top of the inner loop for counting the files.
2. search in each file for xml:id="id1" , xml:id="id2", etc and replace them with: f"xml:id="{counter}_id1"