### PR TITLE
Adding a script to copy figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Convert the toctree.rst files with the script `python toctree2xml.py`
 
     python ~/Runestone/Runestone2PreTeXt/toctree2xml.py /path/to/bookfolder
 
+### Copy figures
+Run the script `copy_figs.py` to copy any images (png, jpeg, svg, gif, etc) in the rst source to the pretext folder:
+
+    python ~/Runestone/Runestone2PreTeXt/copy_figs.py /path/to/_source /path/to/pretext/Figures
+
+where `/path/to/pretext/Figures` is the directory specified as `external` in `publication-rs-for-all.xml`.
+
 ### Build the PreTeXt book
 
 Run `pretext build web`
@@ -96,4 +103,4 @@ If you discover something that the above scripts do not handle but you recognize
 
 TODO:
 
--   Need a better way to get images into the build directory for PreTeXt
+- ~~Need a better way to get images into the build directory for PreTeXt~~ hopefully addressed with copy_figs.py

--- a/copy_figs.py
+++ b/copy_figs.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import sys
+import os
+import shutil
+
+IMG_EXTS = [
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".pdf",
+    ".eps",
+    ".tif",
+    ".tiff",
+    ".bmp",
+]
+
+
+def copy_figs(sourcedir: Path, destdir: Path) -> None:
+    """
+    Recursively copies figures in sourcedir to external dir, retaining directory structure.
+    """
+    for f in sourcedir.iterdir():
+        if f.suffix.lower() in IMG_EXTS:
+            # create the destination directory if it doesn't exist
+            destdir.mkdir(parents=True, exist_ok=True)
+            print(f"Copying {f} to {destdir}")
+            # copy with metadata preservation
+            shutil.copy2(f, destdir)
+
+
+def main(sourcedir: Path, destdir: Path) -> None:
+    """
+    Traverses sourcedir looking for images and copies them to destdir.
+    Preserves relative directory structure.
+    """
+    for root, _, _ in os.walk(sourcedir):
+        root = Path(root)
+        copy_figs(root, destdir / root.relative_to(sourcedir))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        sourcedir = Path(sys.argv[1])
+        destdir = Path(sys.argv[2])
+        main(sourcedir, destdir)
+    else:
+        print(
+            """Usage: python copy_figs.py <sourcedir> <destdir>
+where <sourcedir> is the rst source directory and <destdir> is the PreTeXt external assets directory.
+"""
+        )

--- a/copy_figs.py
+++ b/copy_figs.py
@@ -19,7 +19,8 @@ IMG_EXTS = [
 
 def copy_figs(sourcedir: Path, destdir: Path) -> None:
     """
-    Recursively copies figures in sourcedir to external dir, retaining directory structure.
+    Copies figures from sourcedir to destdir, creating any necessary subdirectories.
+    Figures defined as files with extensions in IMG_EXTS, case insensitive.
     """
     for f in sourcedir.iterdir():
         if f.suffix.lower() in IMG_EXTS:
@@ -32,8 +33,7 @@ def copy_figs(sourcedir: Path, destdir: Path) -> None:
 
 def main(sourcedir: Path, destdir: Path) -> None:
     """
-    Traverses sourcedir looking for images and copies them to destdir.
-    Preserves relative directory structure.
+    Walks through the sourcedir and copies any figures to the destdir, preserving directory structure.
     """
     for root, _, _ in os.walk(sourcedir):
         root = Path(root)


### PR DESCRIPTION
This script goes through the files in the rst source and looks for image files, then copies them over to the pretext external assets directory along with any necessary subdirectories. "Figures" are defined based on a short list of common image extensions, so there's probably some improvemenst to be made there.