### PR TITLE
Blank out comments since they may contain illegal -- sequence.

### DIFF
--- a/docutils2ptx.xsl
+++ b/docutils2ptx.xsl
@@ -298,9 +298,6 @@
     </xsl:template>
 
     <xsl:template match="comment">
-        <xsl:comment>
-            <xsl:value-of select="." />
-        </xsl:comment>
     </xsl:template>
 
     <!-- ignore the inline element that contains the content (link title) -->


### PR DESCRIPTION
In CSAwesome there are rst elements commented out by placing `..` in front of the element. Unfortunately if the text as a whole contains `--`, as this example does, we can't put the text inside an XML comment because `--` is illegal. So this quick hack changes the XSLT to just not render comments. Which is maybe not ideal but seems maybe okay for getting a conversion done.

```
.. .. parsonsprob:: oopex1muc
   :numbered: left
   :practice: T
   :adaptive:
   :noindent:

   The following program segment should create an abstract class with an abstract method walk(). But, the blocks have been mixed up.  Drag the blocks from the left and put them in the correct order on the right.  Click the Check button to check your solution.
   -----
   public abstract class Dog {
   =====
   public class Dog abstract { #distractor
   =====
           public abstract void walk();
   =====
           public void walk(); #distractor
   =====
   } // end class

```