### PR TITLE
Break after blank line.

### DIFF
--- a/toctree2xml.py
+++ b/toctree2xml.py
@@ -70,6 +70,8 @@ def convert_one_toctree(root, path):
             fname = line.replace(".rst", "").strip()
             if fname:
                 ttx.write(f"        <xi:include href='./{fname}.ptx' />\n")
+            if re.match(r"^\s*$", line):
+                break;
 
         ttx.write("    </chapter>\n")
 


### PR DESCRIPTION
From the comments it seems like this what was originally intended. Anyway, it is needed to deal with some of the toctree files in CSAwesome.