### PR TITLE
Fill toc script

### DIFF
--- a/docutils2ptx.xsl
+++ b/docutils2ptx.xsl
@@ -371,9 +371,13 @@
         <xsl:text>[TARGET]</xsl:text>
     </xsl:template>
 
+    <xsl:template match="compound[contains(@classes, 'toctree-wrapper')]">
+      <tocToBeReplaced/>
+    </xsl:template>
+
     <xsl:template match="compound">
         <xsl:message>Ignoring Compound for now</xsl:message>
-        <xsl:text>[COMPOUND]</xsl:text>
+        <xsl:text>[UNKNOWN COMPOUND]</xsl:text>
     </xsl:template>
 
     <xsl:template match="substitution_definition"></xsl:template>

--- a/filltoc.py
+++ b/filltoc.py
@@ -4,6 +4,10 @@
 # includes. The initial XSLT conversion translates the toctree nodes into a
 # marker tag that we can find and replace with the appropriate XML.
 #
+# Note this script does not replace the toctree2xml.py script which is still
+# used for the toctree.rst files. This script should be run after toctree2xml in
+# order to fix up any remaining toctree elements in the rest of the rst files.
+#
 # %%
 
 from pathlib import Path
@@ -47,7 +51,7 @@ def getTOC(rstfile):
 
 def toc2xml(names):
     return [f"<xi:include href='./{name}.ptx'/>\n" for name in names]
-    
+
 
 def processPTX(ptx, ptxdir, sourcedir):
     lines = []
@@ -88,9 +92,9 @@ def walk(ptxdir, sourcedir):
             if ptx.suffix == '.ptx':
                 processPTX(Path(root) / ptx, ptxdir, sourcedir)
 
-            
+
 if __name__ == '__main__':
-    
+
     ptxdir, sourcedir, *files = [Path(p) for p in sys.argv[1:]]
 
     if not files:
@@ -98,4 +102,3 @@ if __name__ == '__main__':
     else:
         for f in files:
             processPTX(f, ptxdir, sourcedir)
-

--- a/filltoc.py
+++ b/filltoc.py
@@ -1,0 +1,101 @@
+# %% [markdown]
+#
+# We need to fill in the places where the .rst contained a toctree with XML
+# includes. The initial XSLT conversion translates the toctree nodes into a
+# marker tag that we can find and replace with the appropriate XML.
+#
+# %%
+
+from pathlib import Path
+import os
+import re
+import sys
+
+
+blank = re.compile(r'^\s*$')
+comment = re.compile('^\s*\.\. ')
+marker = re.compile(r'^\s*<tocToBeReplaced/>\s*$')
+toctree = re.compile(r'^\s*.. toctree::\s*')
+element = re.compile(r'(<\w+)')
+addXi = r'\1 xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US"';
+
+
+def is_blank(line):
+    return blank.fullmatch(line)
+
+def is_comment(line):
+    return comment.match(line)
+
+def getTOC(rstfile):
+    state = 'start'
+    toc_names = []
+    with open(rstfile) as f:
+        for line in f:
+            if state == 'start' and toctree.fullmatch(line):
+                state = 'saw_toctree'
+            elif state == 'saw_toctree' and is_blank(line):
+                state = 'in_toc'
+            elif state == 'in_toc':
+                if is_blank(line):
+                    break
+                elif is_comment(line):
+                    pass
+                else:
+                    toc_names.append(re.sub(r'\.rst$', '', line.strip()))
+    return toc_names
+
+
+def toc2xml(names):
+    return [f"<xi:include href='./{name}.ptx'/>\n" for name in names]
+    
+
+def processPTX(ptx, ptxdir, sourcedir):
+    lines = []
+    saw_marker = False
+    found_root = False
+    with open(ptx) as f:
+        for line in f:
+            if not found_root:
+                fixed, n = element.subn(addXi, line, count=1)
+                if n == 1:
+                    found_root = True
+                    lines.append(fixed)
+                else:
+                    lines.append(line)
+            elif marker.fullmatch(line):
+                saw_marker = True
+                rst = sourcedir / ptx.relative_to(ptxdir).parent / (ptx.stem + '.rst')
+                for toc in toc2xml(getTOC(rst)):
+                    lines.append(toc)
+            else:
+                lines.append(line)
+
+    if saw_marker:
+        savePTX(ptx, lines)
+
+
+def savePTX(ptx, lines):
+    print(f"Filled TOC in {ptx}", file=sys.stderr)
+    with open(ptx, "w") as f:
+        for line in lines:
+            f.write(line)
+
+
+def walk(ptxdir, sourcedir):
+    for root, dirs, files in os.walk(ptxdir):
+        for f in files:
+            ptx = Path(f)
+            if ptx.suffix == '.ptx':
+                processPTX(Path(root) / ptx, ptxdir, sourcedir)
+
+            
+if __name__ == '__main__':
+    
+    ptxdir, sourcedir, *files = [Path(p) for p in sys.argv[1:]]
+
+    if not files:
+        walk(ptxdir, sourcedir)
+    else:
+        for f in files:
+            processPTX(f, ptxdir, sourcedir)
+

--- a/toctree2xml.py
+++ b/toctree2xml.py
@@ -71,7 +71,7 @@ def convert_one_toctree(root, path):
             if fname:
                 ttx.write(f"        <xi:include href='./{fname}.ptx' />\n")
             if re.match(r"^\s*$", line):
-                break;
+                break
 
         ttx.write("    </chapter>\n")
 


### PR DESCRIPTION
This script seems generally useful if any other books use `.. toctree` directives other than in `toctree.rst` files.