### PR TITLE
Remove unnecssary underbars at the start of xml ids.

### DIFF
--- a/fixIds.py
+++ b/fixIds.py
@@ -6,6 +6,7 @@ seen = defaultdict(int)
 
 def rewrite_id(m):
     text = re.sub(r'\s+', "-", m.group(1))
+    text = re.sub(r'^_+', r'', text)
     text = re.sub(r'^(\d)', r'_\1', text)
     text = uniquify(text or "empty")
     return f'xml:id="{text}"'


### PR DESCRIPTION
I think some other part of the process, being conservative, puts `_` at the front of every xml:id. This script runs later to make sure that no ids start with digits. But now we can safely take off the `_`s before putting back just the ones needed because the id starts with a digit.